### PR TITLE
Update toolchain from Firmware

### DIFF
--- a/toolchain/Toolchain-arm-linux-gnueabihf.cmake
+++ b/toolchain/Toolchain-arm-linux-gnueabihf.cmake
@@ -46,6 +46,18 @@
 
 include(CMakeForceCompiler)
 
+if ("$ENV{HEXAGON_SDK_ROOT}" STREQUAL "")
+        message(FATAL_ERROR "HEXAGON_SDK_ROOT not set")
+else()
+        set(HEXAGON_SDK_ROOT $ENV{HEXAGON_SDK_ROOT})
+endif()
+
+if ("$ENV{HEXAGON_ARM_SYSROOT}" STREQUAL "")
+        message(FATAL_ERROR "HEXAGON_ARM_SYSROOT not set")
+else()
+        set(HEXAGON_TOOLS_ROOT $ENV{HEXAGON_ARM_SYSROOT})
+endif()
+
 # this one is important
 set(CMAKE_SYSTEM_NAME Generic)
 
@@ -53,13 +65,21 @@ set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_VERSION 1)
 
 # specify the cross compiler
-find_program(C_COMPILER arm-linux-gnueabihf-gcc)
+find_program(C_COMPILER arm-linux-gnueabihf-gcc
+	PATHS ${HEXAGON_SDK_ROOT}/gcc-linaro-arm-linux-gnueabihf-4.8-2013.08_linux/bin
+	NO_DEFAULT_PATH
+	)
+
 if(NOT C_COMPILER)
 	message(FATAL_ERROR "could not find arm-linux-gnueabihf-gcc compiler")
 endif()
 cmake_force_c_compiler(${C_COMPILER} GNU)
 
-find_program(CXX_COMPILER arm-linux-gnueabihf-g++)
+find_program(CXX_COMPILER arm-linux-gnueabihf-g++
+	PATHS ${HEXAGON_SDK_ROOT}/gcc-linaro-arm-linux-gnueabihf-4.8-2013.08_linux/bin
+	NO_DEFAULT_PATH
+	)
+
 if(NOT CXX_COMPILER)
 	message(FATAL_ERROR "could not find arm-linux-gnueabihf-g++ compiler")
 endif()
@@ -68,14 +88,17 @@ cmake_force_cxx_compiler(${CXX_COMPILER} GNU)
 # compiler tools
 foreach(tool objcopy nm ld)
 	string(TOUPPER ${tool} TOOL)
-	find_program(${TOOL} arm-linux-gnueabihf-${tool})
+	find_program(${TOOL} arm-linux-gnueabihf-${tool}
+		PATHS ${HEXAGON_SDK_ROOT}/gcc-linaro-arm-linux-gnueabihf-4.8-2013.08_linux/bin
+		NO_DEFAULT_PATH
+		)
 	if(NOT ${TOOL})
 		message(FATAL_ERROR "could not find arm-linux-gnueabihf-${tool}")
 	endif()
 endforeach()
 
 # os tools
-foreach(tool echo grep rm mkdir nm cp touch make unzip)
+foreach(tool echo patch grep rm mkdir nm genromfs cp touch make unzip)
 	string(TOUPPER ${tool} TOOL)
 	find_program(${TOOL} ${tool})
 	if(NOT ${TOOL})
@@ -83,15 +106,17 @@ foreach(tool echo grep rm mkdir nm cp touch make unzip)
 	endif()
 endforeach()
 
+set(C_FLAGS "--sysroot=${HEXAGON_ARM_SYSROOT}")
 set(LINKER_FLAGS "-Wl,-gc-sections")
 set(CMAKE_EXE_LINKER_FLAGS ${LINKER_FLAGS})
+set(CMAKE_C_FLAGS ${C_FLAGS})
+set(CMAKE_CXX_LINKER_FLAGS ${C_FLAGS})
 
-# where is the target environment 
+# where is the target environment
 set(CMAKE_FIND_ROOT_PATH  get_file_component(${C_COMPILER} PATH))
 
 # search for programs in the build host directories
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-
 # for libraries and headers in the target directories
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
This updates the apps processor toolchain with the one from PX4, so that the PX4 build system can directly use this now.

@mcharleb 
