### PR TITLE
toolchain: patch and genromfs are not needed

### DIFF
--- a/toolchain/Toolchain-arm-linux-gnueabihf.cmake
+++ b/toolchain/Toolchain-arm-linux-gnueabihf.cmake
@@ -98,7 +98,7 @@ foreach(tool objcopy nm ld)
 endforeach()
 
 # os tools
-foreach(tool echo patch grep rm mkdir nm genromfs cp touch make unzip)
+foreach(tool echo grep rm mkdir nm cp touch make unzip)
 	string(TOUPPER ${tool} TOOL)
 	find_program(${TOOL} ${tool})
 	if(NOT ${TOOL})


### PR DESCRIPTION
It looks like the tools`genromfs` and `patch` were just copied from the NuttX build but are not actually needed. Let's cut down on dependencies.
