### PR TITLE
s/wait-for-devices/wait-for-device/

### DIFF
--- a/linux_app.cmake
+++ b/linux_app.cmake
@@ -71,7 +71,7 @@ function(FASTRPC_ARM_LINUX_LOAD)
 	# Add a rule to load the file onto the target
 	add_custom_target(${FASTRPC_ARM_LINUX_LOAD_LOADNAME}-load
 		DEPENDS ${FASTRPC_ARM_LINUX_LOAD_DEPNAME}
-		COMMAND adb wait-for-devices
+		COMMAND adb wait-for-device
 		COMMAND adb push ${FASTRPC_ARM_LINUX_LOAD_TARGET} ${FASTRPC_ARM_LINUX_LOAD_DEST}
 		COMMAND echo "Pushed ${FASTRPC_ARM_LINUX_LOAD_TARGET} to ${FASTRPC_ARM_LINUX_LOAD_DEST}"
 		)

--- a/qurt_lib.cmake
+++ b/qurt_lib.cmake
@@ -125,7 +125,7 @@ function (QURT_LIB)
 		# Add a rule to load the files onto the target that run in the DSP
 		add_custom_target(lib${QURT_LIB_IDL_NAME}_skel-load
 			DEPENDS ${QURT_LIB_IDL_NAME}_skel
-			COMMAND adb wait-for-devices
+			COMMAND adb wait-for-device
 			COMMAND adb push lib${QURT_LIB_IDL_NAME}_skel.so /usr/share/data/adsp/
 			COMMAND echo "Pushed lib${QURT_LIB_IDL_NAME}_skel.so /usr/share/data/adsp/"
 			)
@@ -133,7 +133,7 @@ function (QURT_LIB)
 		# Add a rule to load the files onto the target that run in the DSP
 		add_custom_target(lib${QURT_LIB_LIB_NAME}-load
 			DEPENDS ${QURT_LIB_LIB_NAME} ${QURT_LIB_IDL_NAME}_skel
-			COMMAND adb wait-for-devices
+			COMMAND adb wait-for-device
 			COMMAND adb push lib${QURT_LIB_IDL_NAME}_skel.so /usr/share/data/adsp/
 			COMMAND adb push lib${QURT_LIB_LIB_NAME}.so /usr/share/data/adsp/
 			COMMAND echo "Pushed lib${QURT_LIB_LIB_NAME}.so and dependencies to /usr/share/data/adsp/"


### PR DESCRIPTION
adb used to accept wait-for-\* as a command but now it demands
"wait-for-device" so modify cmake to reflect this
