### PR TITLE
Added a new helper macro to build qurt lib with not fastrpc dependency.

### DIFF
--- a/linux_app.cmake
+++ b/linux_app.cmake
@@ -93,6 +93,8 @@ function (LINUX_LIB)
 		${FASTRPC_ARM_LINUX_INCLUDES}
 		)
 
+	add_definitions( "-DDSP_TYPE_${DSP_TYPE}" )
+
 	#message("LINUX_LIB_INCS = ${LINUX_LIB_INCS}")
 
 	if (NOT "${LINUX_LIB_SOURCES}" STREQUAL "")
@@ -149,6 +151,8 @@ function (LINUX_APP)
 		${CMAKE_CURRENT_BINARY_DIR}
 		${FASTRPC_ARM_LINUX_INCLUDES}
 		)
+
+	add_definitions( "-DDSP_TYPE_${DSP_TYPE}" )
 
 	#message("LINUX_APP_INCS = ${LINUX_APP_INCS}")
 

--- a/qurt_lib.cmake
+++ b/qurt_lib.cmake
@@ -58,40 +58,6 @@ include(fastrpc)
 
 include (CMakeParseArguments)
 
-#function to build qurt lib with no fastrpc dependency.
-function (QURT_LIB_STANDALONE)
-	set(options)
-	set( oneValueArgs LIB_NAME )
-	set( multiValueArgs SOURCES LINK_LIBS INCS FLAGS )
-	cmake_parse_arguments(QURT_LIB_STANDALONE "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
-	if( "${QURT_LIB_STANDALONE_LIB_NAME}" STREQUAL "" )
-		message( FATAL_ERROR "QURT_LIB_STANDALONE called without a target name" )
-	endif()
-
-	message( "QURT_LIB_STANDALONE_LIB_NAME = ${QURT_LIB_STANDALONE_LIB_NAME}" )
-
-	include_directories(
-		${CMAKE_CURRENT_BINARY_DIR}
-		${FASTRPC_DSP_INCLUDES}
-		)
-
-	add_library( ${QURT_LIB_STANDALONE_LIB_NAME} SHARED ${QURT_LIB_STANDALONE_SOURCES} )
-	set_property(TARGET ${QURT_LIB_STANDALONE_LIB_NAME} PROPERTY POSITION_INDEPENDENT_CODE TRUE)
-
-  if(NOT ${QURT_LIB_STANDALONE_LIBS} STREQUAL "" )
-		target_link_libraries( ${QURT_LIB_STANDALONE_LIB_NAME} ${QURT_LIB_STANDALONE_LIBS} )
-	endif()
-
-	target_include_directories(${QURT_LIB_STANDALONE_LIB_NAME} PUBLIC
-	   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>
-	   $<INSTALL_INTERFACE:include>)
-
-	target_include_directories(${QURT_LIB_STANDALONE_LIB_NAME} PUBLIC
-	   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/>
-	   $<INSTALL_INTERFACE:include>)
-
-endfunction()
-
 # Process DSP files
 function (QURT_LIB)
 	set(options)

--- a/qurt_lib.cmake
+++ b/qurt_lib.cmake
@@ -58,6 +58,40 @@ include(fastrpc)
 
 include (CMakeParseArguments)
 
+#function to build qurt lib with no fastrpc dependency.
+function (QURT_LIB_STANDALONE)
+	set(options)
+	set( oneValueArgs LIB_NAME )
+	set( multiValueArgs SOURCES LINK_LIBS INCS FLAGS )
+	cmake_parse_arguments(QURT_LIB_STANDALONE "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+	if( "${QURT_LIB_STANDALONE_LIB_NAME}" STREQUAL "" )
+		message( FATAL_ERROR "QURT_LIB_STANDALONE called without a target name" )
+	endif()
+
+	message( "QURT_LIB_STANDALONE_LIB_NAME = ${QURT_LIB_STANDALONE_LIB_NAME}" )
+
+	include_directories(
+		${CMAKE_CURRENT_BINARY_DIR}
+		${FASTRPC_DSP_INCLUDES}
+		)
+
+	add_library( ${QURT_LIB_STANDALONE_LIB_NAME} SHARED ${QURT_LIB_STANDALONE_SOURCES} )
+	set_property(TARGET ${QURT_LIB_STANDALONE_LIB_NAME} PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+
+  if(NOT ${QURT_LIB_STANDALONE_LIBS} STREQUAL "" )
+		target_link_libraries( ${QURT_LIB_STANDALONE_LIB_NAME} ${QURT_LIB_STANDALONE_LIBS} )
+	endif()
+
+	target_include_directories(${QURT_LIB_STANDALONE_LIB_NAME} PUBLIC
+	   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>
+	   $<INSTALL_INTERFACE:include>)
+
+	target_include_directories(${QURT_LIB_STANDALONE_LIB_NAME} PUBLIC
+	   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/>
+	   $<INSTALL_INTERFACE:include>)
+
+endfunction()
+
 # Process DSP files
 function (QURT_LIB)
 	set(options)


### PR DESCRIPTION
Exported the DSP_TYPE_$DSP_TYPE variable to apps build as needed to build the TimeSynchornization util for IMU.

Signed-off-by: Ramakrishna Kintada rkintada@gmail.com
