### PR TITLE
Updated the linux_app and linux_lib macros to compile in the sources …

### DIFF
--- a/fastrpc.cmake
+++ b/fastrpc.cmake
@@ -74,11 +74,9 @@ else()
 endif()
 
 set(ADSPMSGD ${HEXAGON_SDK_ROOT}/${SDKLIB}/common/adspmsgd/ship/UbuntuARM_${RELEASE}/adspmsgd.a)
-set(RPCMEM ${HEXAGON_SDK_ROOT}/${SDKLIB}/common/rpcmem/UbuntuARM_${RELEASE}/rpcmem.a)
 
 set(FASTRPC_ARM_LIBS
 	${ADSPRPC}
-	${RPCMEM}
 	)
 
 	

--- a/linux_app.cmake
+++ b/linux_app.cmake
@@ -103,6 +103,7 @@ function (LINUX_LIB)
 		add_library(${LINUX_LIB_LIB_NAME} SHARED
 			${LINUX_LIB_SOURCES}
 			${LINUX_LIB_IDL_NAME}_stub.c
+			${HEXAGON_SDK_ROOT}/${SDKLIB}/common/rpcmem/rpcmem.c
 			)
 
 		if (NOT "${LINUX_LIB_FLAGS}" STREQUAL "")
@@ -160,6 +161,7 @@ function (LINUX_APP)
 	add_executable(${LINUX_APP_APP_NAME}
 		${LINUX_APP_SOURCES}
 		${LINUX_APP_IDL_NAME}_stub.c
+		${HEXAGON_SDK_ROOT}/${SDKLIB}/common/rpcmem/rpcmem.c
 		)
 
 	if (NOT "${LINUX_APP_INCS}" STREQUAL "")


### PR DESCRIPTION
…for rpcmem instead of linking to a pre-compiled library from HexagonSDK

Signed-off-by: Ramakrishna Kintada rkintada@gmail.com
