### PR TITLE
toolchain updates for flight pro 8096 kyro cross compilation

### DIFF
--- a/fastrpc.cmake
+++ b/fastrpc.cmake
@@ -68,7 +68,7 @@ set(FASTRPC_ARM_LINUX_INCLUDES
 if ("${DSP_TYPE}" STREQUAL "ADSP")
 	set(ADSPRPC -L${HEXAGON_SDK_ROOT}/${SDKLIB}/common/remote/ship/UbuntuARM_${RELEASE} -ladsprpc)
 elseif("${DSP_TYPE}" STREQUAL "SLPI")
-	set(ADSPRPC -L${HEXAGON_SDK_ROOT}/${SDKLIB}/common/remote/ship/UbuntuARM_${RELEASE} -lsdsprpc)
+	set(ADSPRPC -lsdsprpc)
 else()
 	message(FATAL_ERROR "DSP_TYPE not defined")
 endif()

--- a/toolchain/Toolchain-arm-oemllib32-linux-gnueabi.cmake
+++ b/toolchain/Toolchain-arm-oemllib32-linux-gnueabi.cmake
@@ -46,16 +46,10 @@
 
 include(CMakeForceCompiler)
 
-if ("$ENV{HEXAGON_SDK_ROOT}" STREQUAL "")
-        message(FATAL_ERROR "HEXAGON_SDK_ROOT not set")
+if ("$ENV{SDKROOT}" STREQUAL "")
+				message(FATAL_ERROR "SDKROOT not set")
 else()
-        set(HEXAGON_SDK_ROOT $ENV{HEXAGON_SDK_ROOT})
-endif()
-
-if ("$ENV{HEXAGON_ARM_SYSROOT}" STREQUAL "")
-        message(FATAL_ERROR "HEXAGON_ARM_SYSROOT not set")
-else()
-        set(HEXAGON_ARM_SYSROOT $ENV{HEXAGON_ARM_SYSROOT})
+				set(SDKROOT $ENV{SDKROOT})
 endif()
 
 # this one is important
@@ -67,8 +61,8 @@ set(CMAKE_SYSTEM_VERSION 1)
 # specify the cross compiler
 
 #temporary variables to set up the cross compilation environment
-set(ARM_CROSS_COMPILIER_PREFIX "arm-oemllib32-linux-gnueabi" )
-set(ARM_COMPILER_PATH "${HEXAGON_ARM_SYSROOT}/x86_64-linux/usr/bin/${ARM_CROSS_COMPILIER_PREFIX}" )
+set(ARM_CROSS_COMPILIER_PREFIX "arm-oemllib32-linux" )
+set(ARM_COMPILER_PATH "${SDKROOT}/sysroots/x86_64-oesdk-linux/usr/bin/${ARM_CROSS_COMPILIER_PREFIX}" )
 set(ARM_C_COMPILER "${ARM_CROSS_COMPILIER_PREFIX}-gcc" )
 set(ARM_CPP_COMPILER "${ARM_CROSS_COMPILIER_PREFIX}-g++" )
 
@@ -113,9 +107,7 @@ foreach(tool echo grep rm mkdir nm cp touch make unzip)
 	endif()
 endforeach()
 
-#override the ARM sysroot.
-set(CMAKE_SYSROOT "${HEXAGON_ARM_SYSROOT}/lib32-apq8096" )
-set(CMAKE_EXE_LINKER_FLAGS "-Wl,-gc-sections -Wl,-rpath-link,${CMAKE_SYSROOT}/usr/lib/${ARM_CROSS_COMPILIER_PREFIX} -Wl,-rpath-link,${CMAKE_SYSROOT}/lib/${ARM_CROSS_COMPILIER_PREFIX}" )
+set(CMAKE_SYSROOT ${SDKROOT}/sysroots/aarch64-oe-linux)
 
 # where is the target environment
 set(CMAKE_FIND_ROOT_PATH  get_file_component(${C_COMPILER} PATH))


### PR DESCRIPTION
These changes allow the `linux_app.cmake` macros to correctly build binaries and shared objects. The preconditions for using this toolchain with the sfpro is that the Intrinsyc instructions for setting up the cross-compilation environment and the DSPAL/SLPI dev env have been completed.

**Note:** by removing the search path to `sdsprpc.so` (`${HEXAGON_SDK_ROOT}/${SDKLIB}/common/remote/ship/UbuntuARM_${RELEASE}`), we allow the linker to find the correct `sdsprpc.so` (correct in the sense that it is a soft-float abi). Without this change, the following error about `VFP register arguments` occurs:

```bash
/home/dspal/Qualcomm/cross_compiler/sysroots/x86_64-oesdk-linux/usr/libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/4.9.3/real-ld: error: \
/home/dspal/Qualcomm/Hexagon_SDK/3.1/libs/common/remote/ship/UbuntuARM_Debug/libsdsprpc.so uses VFP register arguments, output does not
```

The linker is complaining that the compiler being used (from the Intrinsyc cross-compiler toolchain) does not have a hard-float abi, but the `sdsprpc.so` in the Hexagon SDK does [1]. This is verified using `readelf -A libsdsprpc.so`:

```bash
$ readelf -A Qualcomm/Hexagon_SDK/3.1/libs/common/remote/ship/UbuntuARM_Debug/libadsprpc.so 
Attribute Section: aeabi
File Attributes
  Tag_CPU_name: "7-A"
  Tag_CPU_arch: v7
  Tag_CPU_arch_profile: Application
  Tag_ARM_ISA_use: Yes
  Tag_THUMB_ISA_use: Thumb-2
  Tag_FP_arch: VFPv3
  Tag_Advanced_SIMD_arch: NEONv1
  Tag_ABI_PCS_wchar_t: 4
  Tag_ABI_FP_rounding: Needed
  Tag_ABI_FP_denormal: Needed
  Tag_ABI_FP_exceptions: Needed
  Tag_ABI_FP_number_model: IEEE 754
  Tag_ABI_align_needed: 8-byte
  Tag_ABI_align_preserved: 8-byte, except leaf SP
  Tag_ABI_enum_size: int
  Tag_ABI_HardFP_use: Deprecated
  Tag_ABI_VFP_args: VFP registers                  # <--- indicates hard-float abi
  Tag_ABI_optimization_goals: Aggressive Debug
  Tag_CPU_unaligned_access: v6
```
However, when we check the lib in the target sysroot:

```bash
$ readelf -A Qualcomm/cross_compiler/sysroots/aarch64-oe-linux/usr/lib/libsdsprpc.so
Attribute Section: aeabi
File Attributes
  Tag_CPU_name: "7-A"
  Tag_CPU_arch: v7
  Tag_CPU_arch_profile: Application
  Tag_ARM_ISA_use: Yes
  Tag_THUMB_ISA_use: Thumb-2
  Tag_FP_arch: VFPv3
  Tag_Advanced_SIMD_arch: NEONv1
  Tag_ABI_PCS_wchar_t: 4
  Tag_ABI_FP_rounding: Needed
  Tag_ABI_FP_denormal: Needed
  Tag_ABI_FP_exceptions: Needed
  Tag_ABI_FP_number_model: IEEE 754
  Tag_ABI_align_needed: 8-byte
  Tag_ABI_enum_size: int
  Tag_ABI_HardFP_use: Deprecated
  Tag_CPU_unaligned_access: v6
```

That line is not present because a soft-float abi is being used.

It seems that using the `qurt_bundle` CMake macro does not expose this problem because of the `add_custom_target` stanza:

```cmake
add_custom_target(${QURT_BUNDLE_APP_NAME}_app ALL
    COMMAND ${QURT_BUNDLE_APPS_COMPILER}  ${${QURT_BUNDLE_APP_NAME}_INCLUDE_DIRS} ${QAIC_INCLUDE_DIRS} -o ${CMAKE_CURRENT_BINARY_DIR}/${QURT_BUNDLE_APP_NAME} ${QURT_BUNDLE_APPS_SOURCES} ${HEXAGON_SDK_ROOT}/${SDKLIB}/common/rpcmem/src/rpcmem.c "${CMAKE_CURRENT_BINARY_DIR}/${QURT_BUNDLE_IDL_NAME}_stub.c" ${FASTRPC_ARM_LIBS}
    DEPENDS generate_${QURT_BUNDLE_IDL_NAME}_stubs
    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
)
```

where `APPS_COMPILER` tends to be passed in as `Qualcomm/ARM_Tools/gcc-4.9-2014.11/bin/arm-linux-gnueabihf-gcc`, which has a hard-float abi [2].

---

[1]: This is likely related to the fact that Snapdragon 820 has a Kyro CPU, based on ARMv8-A (64 bit), but for some reason the yocto linux shipped is 32-bit.
[2]: Maybe this is actually itself a problem? Why do we have both soft-float and hard-float abi compilers? Why is the shipped OS 32-bit?